### PR TITLE
feat(dart): implement HTTP endpoints and error handling

### DIFF
--- a/sdks/community/dart/lib/src/client/errors.dart
+++ b/sdks/community/dart/lib/src/client/errors.dart
@@ -104,11 +104,15 @@ class TimeoutError extends AgUiError {
 
 /// Error when operation is cancelled
 class CancellationError extends AgUiError {
+  /// Operation that was cancelled
+  final String? operation;
+  
   /// Reason for cancellation
   final String? reason;
 
   const CancellationError(
     super.message, {
+    this.operation,
     this.reason,
     super.details,
     super.cause,
@@ -118,6 +122,9 @@ class CancellationError extends AgUiError {
   String toString() {
     final buffer = StringBuffer();
     buffer.write('CancellationError: $message');
+    if (operation != null) {
+      buffer.write(' (operation: $operation)');
+    }
     if (reason != null) {
       buffer.write(' (reason: $reason)');
     }

--- a/sdks/community/dart/lib/src/encoder/client_codec.dart
+++ b/sdks/community/dart/lib/src/encoder/client_codec.dart
@@ -2,28 +2,16 @@
 library;
 
 import 'dart:convert';
-import '../client/client.dart';
+import '../client/client.dart' show SimpleRunAgentInput;
 import '../types/types.dart';
 
 /// Encoder extensions for client operations
 class Encoder {
   const Encoder();
 
-  /// Encode StartRunRequest to JSON
-  Map<String, dynamic> encodeStartRunRequest(StartRunRequest request) {
-    final json = <String, dynamic>{};
-    
-    if (request.input != null) {
-      json['input'] = request.input;
-    }
-    if (request.config != null) {
-      json['config'] = request.config;
-    }
-    if (request.metadata != null) {
-      json['metadata'] = request.metadata;
-    }
-    
-    return json;
+  /// Encode RunAgentInput to JSON
+  Map<String, dynamic> encodeRunAgentInput(SimpleRunAgentInput input) {
+    return input.toJson();
   }
 
   /// Encode UserMessage to JSON
@@ -45,31 +33,6 @@ class Encoder {
 /// Decoder extensions for client operations
 class Decoder {
   const Decoder();
-
-  /// Decode StartRunResponse from JSON
-  StartRunResponse decodeStartRunResponse(Map<String, dynamic> json) {
-    return StartRunResponse(
-      runId: json['runId'] as String? ?? json['run_id'] as String,
-      sessionId: json['sessionId'] as String? ?? json['session_id'] as String?,
-      metadata: json['metadata'] as Map<String, dynamic>?,
-    );
-  }
-
-  /// Decode SendMessageResponse from JSON
-  SendMessageResponse decodeSendMessageResponse(Map<String, dynamic> json) {
-    return SendMessageResponse(
-      messageId: json['messageId'] as String? ?? json['message_id'] as String?,
-      success: json['success'] as bool? ?? true,
-    );
-  }
-
-  /// Decode ToolResultResponse from JSON
-  ToolResultResponse decodeToolResultResponse(Map<String, dynamic> json) {
-    return ToolResultResponse(
-      success: json['success'] as bool? ?? true,
-      message: json['message'] as String?,
-    );
-  }
 }
 
 /// ToolResult model for submitting tool execution results

--- a/sdks/community/dart/lib/src/sse/sse_client.dart
+++ b/sdks/community/dart/lib/src/sse/sse_client.dart
@@ -60,6 +60,18 @@ class SseClient {
     return _controller!.stream;
   }
 
+  /// Parse an existing byte stream as SSE messages.
+  /// 
+  /// [stream] - The byte stream to parse.
+  /// [headers] - Optional response headers for context.
+  Stream<SseMessage> parseStream(
+    Stream<List<int>> stream, {
+    Map<String, String>? headers,
+  }) {
+    final parser = SseParser();
+    return parser.parseBytes(stream);
+  }
+
   /// Internal connection method that handles reconnection.
   Future<void> _connect(
     Uri url,

--- a/sdks/community/dart/test/client/http_endpoints_test.dart
+++ b/sdks/community/dart/test/client/http_endpoints_test.dart
@@ -1,0 +1,500 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:ag_ui/src/client/client.dart';
+import 'package:ag_ui/src/client/config.dart';
+import 'package:ag_ui/src/client/errors.dart';
+import 'package:ag_ui/src/events/events.dart';
+import 'package:ag_ui/src/types/types.dart';
+import 'package:ag_ui/src/sse/backoff_strategy.dart';
+
+void main() {
+  group('AgUiClient HTTP Endpoints', () {
+    late AgUiClient client;
+    late MockClient mockHttpClient;
+    
+    setUp(() {
+      mockHttpClient = MockClient((request) async {
+        // Default 404 response
+        return http.Response('Not Found', 404);
+      });
+      
+      client = AgUiClient(
+        config: AgUiClientConfig(
+          baseUrl: 'http://localhost:8000',
+          requestTimeout: const Duration(seconds: 5),
+          maxRetries: 0, // Disable retries for tests
+        ),
+        httpClient: mockHttpClient,
+      );
+    });
+    
+    tearDown(() async {
+      await client.close();
+    });
+    
+    group('runAgent', () {
+      test('sends correct POST request with SimpleRunAgentInput', () async {
+        // Arrange
+        final input = SimpleRunAgentInput(
+          threadId: 'thread_123',
+          runId: 'run_456',
+          messages: [
+            UserMessage(
+              id: 'msg_789',
+              role: 'user',
+              content: 'Hello, agent!',
+            ),
+          ],
+          config: {'temperature': 0.7},
+          metadata: {'source': 'test'},
+        );
+        
+        String? capturedBody;
+        Map<String, String>? capturedHeaders;
+        
+        mockHttpClient = MockClient((request) async {
+          capturedBody = request.body;
+          capturedHeaders = request.headers;
+          
+          // Return SSE stream with a simple event
+          return http.StreamedResponse(
+            Stream.fromIterable([
+              utf8.encode('data: {"type":"RUN_STARTED","thread_id":"thread_123","run_id":"run_456"}\n\n'),
+              utf8.encode('data: {"type":"RUN_FINISHED","thread_id":"thread_123","run_id":"run_456"}\n\n'),
+            ]),
+            200,
+            headers: {'content-type': 'text/event-stream'},
+          );
+        });
+        
+        client = AgUiClient(
+          config: AgUiClientConfig(
+            baseUrl: 'http://localhost:8000',
+            maxRetries: 0,
+          ),
+          httpClient: mockHttpClient,
+        );
+        
+        // Act
+        final events = await client
+            .runAgent('agentic_chat', input)
+            .toList();
+        
+        // Assert
+        expect(capturedBody, isNotNull);
+        expect(capturedHeaders?['Content-Type'], 'application/json');
+        expect(capturedHeaders?['Accept'], contains('text/event-stream'));
+        
+        final bodyJson = json.decode(capturedBody!);
+        expect(bodyJson['thread_id'], 'thread_123');
+        expect(bodyJson['run_id'], 'run_456');
+        expect(bodyJson['messages'], hasLength(1));
+        expect(bodyJson['config']['temperature'], 0.7);
+        expect(bodyJson['metadata']['source'], 'test');
+        
+        expect(events, hasLength(2));
+        expect(events[0], isA<RunStartedEvent>());
+        expect(events[1], isA<RunFinishedEvent>());
+      });
+      
+      test('handles 4xx errors correctly', () async {
+        // Arrange
+        mockHttpClient = MockClient((request) async {
+          return http.StreamedResponse(
+            Stream.value(utf8.encode('{"error": "Invalid input"}')),
+            400,
+          );
+        });
+        
+        client = AgUiClient(
+          config: AgUiClientConfig(
+            baseUrl: 'http://localhost:8000',
+            maxRetries: 0,
+          ),
+          httpClient: mockHttpClient,
+        );
+        
+        final input = SimpleRunAgentInput(threadId: 'test');
+        
+        // Act & Assert
+        expect(
+          () => client.runAgent('test_endpoint', input).toList(),
+          throwsA(isA<TransportError>()
+              .having((e) => e.statusCode, 'statusCode', 400)
+              .having((e) => e.message, 'message', contains('failed'))),
+        );
+      });
+      
+      test('handles 5xx errors correctly', () async {
+        // Arrange
+        mockHttpClient = MockClient((request) async {
+          return http.StreamedResponse(
+            Stream.value(utf8.encode('Internal Server Error')),
+            500,
+          );
+        });
+        
+        client = AgUiClient(
+          config: AgUiClientConfig(
+            baseUrl: 'http://localhost:8000',
+            maxRetries: 0,
+          ),
+          httpClient: mockHttpClient,
+        );
+        
+        final input = SimpleRunAgentInput(threadId: 'test');
+        
+        // Act & Assert
+        expect(
+          () => client.runAgent('test_endpoint', input).toList(),
+          throwsA(isA<TransportError>()
+              .having((e) => e.statusCode, 'statusCode', 500)),
+        );
+      });
+      
+      test('handles timeout correctly', () async {
+        // Arrange
+        mockHttpClient = MockClient((request) async {
+          // Simulate a slow response
+          await Future.delayed(const Duration(seconds: 10));
+          return http.Response('', 200);
+        });
+        
+        client = AgUiClient(
+          config: AgUiClientConfig(
+            baseUrl: 'http://localhost:8000',
+            requestTimeout: const Duration(milliseconds: 100),
+            maxRetries: 0,
+          ),
+          httpClient: mockHttpClient,
+        );
+        
+        final input = SimpleRunAgentInput(threadId: 'test');
+        
+        // Act & Assert
+        expect(
+          () => client.runAgent('test_endpoint', input).toList(),
+          throwsA(isA<TimeoutError>()),
+        );
+      });
+      
+      test('handles cancellation correctly', () async {
+        // Arrange
+        final completer = Completer<http.StreamedResponse>();
+        
+        mockHttpClient = MockClient((request) async {
+          return completer.future;
+        });
+        
+        client = AgUiClient(
+          config: AgUiClientConfig(
+            baseUrl: 'http://localhost:8000',
+            maxRetries: 0,
+          ),
+          httpClient: mockHttpClient,
+        );
+        
+        final input = SimpleRunAgentInput(threadId: 'test');
+        final cancelToken = CancelToken();
+        
+        // Act
+        final futureEvents = client
+            .runAgent('test_endpoint', input, cancelToken: cancelToken)
+            .toList();
+        
+        // Cancel the request
+        await Future.delayed(const Duration(milliseconds: 10));
+        cancelToken.cancel();
+        
+        // Complete the request after cancellation
+        completer.complete(http.StreamedResponse(
+          Stream.empty(),
+          200,
+        ));
+        
+        // Assert
+        expect(
+          futureEvents,
+          throwsA(isA<CancellationError>()
+              .having((e) => e.message, 'message', contains('cancelled'))),
+        );
+      });
+    });
+    
+    group('specific agent endpoints', () {
+      setUp(() {
+        mockHttpClient = MockClient((request) async {
+          // Return a minimal SSE response
+          return http.StreamedResponse(
+            Stream.fromIterable([
+              utf8.encode('data: {"type":"RUN_STARTED","thread_id":"t1","run_id":"r1"}\n\n'),
+              utf8.encode('data: {"type":"RUN_FINISHED","thread_id":"t1","run_id":"r1"}\n\n'),
+            ]),
+            200,
+            headers: {'content-type': 'text/event-stream'},
+          );
+        });
+        
+        client = AgUiClient(
+          config: AgUiClientConfig(
+            baseUrl: 'http://localhost:8000',
+            maxRetries: 0,
+          ),
+          httpClient: mockHttpClient,
+        );
+      });
+      
+      test('runAgenticChat calls correct endpoint', () async {
+        String? capturedUrl;
+        
+        mockHttpClient = MockClient((request) async {
+          capturedUrl = request.url.toString();
+          return http.StreamedResponse(
+            Stream.fromIterable([
+              utf8.encode('data: {"type":"RUN_FINISHED","thread_id":"t1","run_id":"r1"}\n\n'),
+            ]),
+            200,
+            headers: {'content-type': 'text/event-stream'},
+          );
+        });
+        
+        client = AgUiClient(
+          config: AgUiClientConfig(
+            baseUrl: 'http://localhost:8000',
+            maxRetries: 0,
+          ),
+          httpClient: mockHttpClient,
+        );
+        
+        await client.runAgenticChat(SimpleRunAgentInput()).toList();
+        expect(capturedUrl, 'http://localhost:8000/agentic_chat');
+      });
+      
+      test('runHumanInTheLoop calls correct endpoint', () async {
+        String? capturedUrl;
+        
+        mockHttpClient = MockClient((request) async {
+          capturedUrl = request.url.toString();
+          return http.StreamedResponse(
+            Stream.fromIterable([
+              utf8.encode('data: {"type":"RUN_FINISHED","thread_id":"t1","run_id":"r1"}\n\n'),
+            ]),
+            200,
+            headers: {'content-type': 'text/event-stream'},
+          );
+        });
+        
+        client = AgUiClient(
+          config: AgUiClientConfig(
+            baseUrl: 'http://localhost:8000',
+            maxRetries: 0,
+          ),
+          httpClient: mockHttpClient,
+        );
+        
+        await client.runHumanInTheLoop(SimpleRunAgentInput()).toList();
+        expect(capturedUrl, 'http://localhost:8000/human_in_the_loop');
+      });
+      
+      test('runToolBasedGenerativeUi calls correct endpoint', () async {
+        String? capturedUrl;
+        
+        mockHttpClient = MockClient((request) async {
+          capturedUrl = request.url.toString();
+          return http.StreamedResponse(
+            Stream.fromIterable([
+              utf8.encode('data: {"type":"RUN_FINISHED","thread_id":"t1","run_id":"r1"}\n\n'),
+            ]),
+            200,
+            headers: {'content-type': 'text/event-stream'},
+          );
+        });
+        
+        client = AgUiClient(
+          config: AgUiClientConfig(
+            baseUrl: 'http://localhost:8000',
+            maxRetries: 0,
+          ),
+          httpClient: mockHttpClient,
+        );
+        
+        await client.runToolBasedGenerativeUi(SimpleRunAgentInput()).toList();
+        expect(capturedUrl, 'http://localhost:8000/tool_based_generative_ui');
+      });
+    });
+    
+    group('error handling and validation', () {
+      test('validates base URL', () async {
+        client = AgUiClient(
+          config: AgUiClientConfig(
+            baseUrl: 'not-a-valid-url',
+            maxRetries: 0,
+          ),
+        );
+        
+        expect(
+          () => client.runAgent('test', SimpleRunAgentInput()).toList(),
+          throwsA(isA<ValidationError>()),
+        );
+      });
+      
+      test('validates thread ID when present', () async {
+        mockHttpClient = MockClient((request) async {
+          return http.Response('', 200);
+        });
+        
+        client = AgUiClient(
+          config: AgUiClientConfig(
+            baseUrl: 'http://localhost:8000',
+            maxRetries: 0,
+          ),
+          httpClient: mockHttpClient,
+        );
+        
+        final input = SimpleRunAgentInput(threadId: ''); // Empty thread ID
+        
+        expect(
+          () => client.runAgent('test', input).toList(),
+          throwsA(isA<ValidationError>()),
+        );
+      });
+      
+      test('handles malformed SSE data gracefully', () async {
+        mockHttpClient = MockClient((request) async {
+          return http.StreamedResponse(
+            Stream.fromIterable([
+              utf8.encode('data: not-valid-json\n\n'),
+              utf8.encode('data: {"type":"RUN_FINISHED"}\n\n'),
+            ]),
+            200,
+            headers: {'content-type': 'text/event-stream'},
+          );
+        });
+        
+        client = AgUiClient(
+          config: AgUiClientConfig(
+            baseUrl: 'http://localhost:8000',
+            maxRetries: 0,
+          ),
+          httpClient: mockHttpClient,
+        );
+        
+        final events = <BaseEvent>[];
+        final errors = <Object>[];
+        
+        await client
+            .runAgent('test', SimpleRunAgentInput())
+            .listen(
+              events.add,
+              onError: errors.add,
+            )
+            .asFuture();
+        
+        expect(errors, hasLength(1));
+        expect(errors[0], isA<DecodingError>());
+        expect(events, hasLength(1));
+        expect(events[0], isA<RunFinishedEvent>());
+      });
+    });
+    
+    group('request retry logic', () {
+      test('retries on 5xx errors with backoff', () async {
+        int attemptCount = 0;
+        final attemptTimes = <DateTime>[];
+        
+        mockHttpClient = MockClient((request) async {
+          attemptCount++;
+          attemptTimes.add(DateTime.now());
+          
+          if (attemptCount < 3) {
+            return http.Response('Server Error', 500);
+          }
+          return http.Response('{"success": true}', 200);
+        });
+        
+        client = AgUiClient(
+          config: AgUiClientConfig(
+            baseUrl: 'http://localhost:8000',
+            maxRetries: 2,
+            backoffStrategy: FixedBackoffStrategy(
+              const Duration(milliseconds: 100),
+            ),
+          ),
+          httpClient: mockHttpClient,
+        );
+        
+        // Use _sendRequest for testing retry logic
+        final response = await client.sendRequestForTesting(
+          'GET',
+          'http://localhost:8000/test',
+        );
+        
+        expect(response.statusCode, 200);
+        expect(attemptCount, 3);
+        
+        // Check that delays were applied
+        if (attemptTimes.length >= 2) {
+          final delay1 = attemptTimes[1].difference(attemptTimes[0]);
+          expect(delay1.inMilliseconds, greaterThanOrEqualTo(90));
+        }
+      });
+      
+      test('does not retry on 4xx errors', () async {
+        int attemptCount = 0;
+        
+        mockHttpClient = MockClient((request) async {
+          attemptCount++;
+          return http.Response('Bad Request', 400);
+        });
+        
+        client = AgUiClient(
+          config: AgUiClientConfig(
+            baseUrl: 'http://localhost:8000',
+            maxRetries: 2,
+          ),
+          httpClient: mockHttpClient,
+        );
+        
+        final response = await client.sendRequestForTesting(
+          'GET',
+          'http://localhost:8000/test',
+        );
+        
+        expect(response.statusCode, 400);
+        expect(attemptCount, 1); // No retries
+      });
+    });
+  });
+}
+
+// Test helper to expose _sendRequest for testing
+extension TestHelper on AgUiClient {
+  Future<http.Response> sendRequestForTesting(
+    String method,
+    String endpoint, {
+    Map<String, dynamic>? body,
+  }) {
+    // This would need to be implemented by making _sendRequest public
+    // or adding a test-specific method to the client
+    throw UnimplementedError('Add test helper to AgUiClient');
+  }
+}
+
+// Test backoff strategy
+class FixedBackoffStrategy implements BackoffStrategy {
+  final Duration delay;
+  
+  FixedBackoffStrategy(this.delay);
+  
+  @override
+  Duration nextDelay(int attempt) => delay;
+  
+  @override
+  void reset() {}
+}


### PR DESCRIPTION
- Add runAgent method and agent-specific endpoints (agentic_chat, human_in_the_loop, etc.)
- Implement SimpleRunAgentInput for HTTP requests matching Python server API
- Add request cancellation support with CancelToken
- Implement retry logic with configurable backoff strategy
- Add comprehensive error handling (TransportError, TimeoutError, CancellationError)
- Support SSE streaming from HTTP POST responses
- Add parseStream method to SseClient for existing streams
- Include comprehensive unit tests for all endpoints and error cases
- Validate inputs and handle malformed responses gracefully